### PR TITLE
Fix for Ice Cream Sandwich connection problems

### DIFF
--- a/server/src/com/mwr/mercury/Shell.java
+++ b/server/src/com/mwr/mercury/Shell.java
@@ -83,10 +83,30 @@ public class Shell
 		{
 			int newByte = 0;
 			
-			while (!returnVal.endsWith("\r\n$ ") && !returnVal.contains("\r\n# ") && (newByte != -1))
-			{
-				newByte = termIn.read();
-				returnVal += (char)newByte;
+			// Get the Android version of the Device
+			int currentapiVersion = android.os.Build.VERSION.SDK_INT;
+			if (currentapiVersion >= 14){ // 14 -> The Ice Cream Sandwich API version.
+				while (true)
+				{
+					// Terminal lines in ICS are different of the ones in Gingerbread
+					if (returnVal.equals("") || (!returnVal.endsWith(" $ ") && 
+							!returnVal.endsWith(" # ") && (newByte != -1)))
+					{
+						newByte = termIn.read();
+					}
+					else
+					{
+						break;
+					}
+					returnVal += (char)newByte;
+				}
+			} else{
+				while (!returnVal.endsWith("\r\n$ ")
+						&& !returnVal.contains("\r\n# ") && (newByte != -1))
+				{
+					newByte = termIn.read();
+					returnVal += (char)newByte;
+				}
 			}
 
 		}


### PR DESCRIPTION
This patch fixes the connection problems on ICS devices, without compromising the connection with older Android devices.

The terminal on ICS returns a String line different from the older devices. 
The Gingerbread device, for example, gives a shell line that look like this:
- "\r\n$ "
  The ICS device, otherwise, gives a shell line like this:
- "app_122@android:/ $ "

So, changing the stop condition of the loop in "read()" function fixed the problem.

Thanks!
