### PR TITLE
Added feature provider -> securityscan

### DIFF
--- a/client/merc/lib/provider.py
+++ b/client/merc/lib/provider.py
@@ -292,13 +292,13 @@ usage: finduri packageName
     def do_securityscan(self, args):
         """
 Get access information about all content providers with optional filter
-usage: info [--filter <filter>]
+usage: securityscan [--filter <vulnerable | safe>] [--package <package name>]
         """
 
         # Define command-line arguments using argparse
         parser = argparse.ArgumentParser(prog = 'info', add_help = False)
         parser.add_argument('--filter', '-f', metavar = '<filter>')
-        parser.add_argument('--permissions', '-p', metavar = '<filter>')
+        parser.add_argument('--package', metavar = '<filter>')
 
 
         try:


### PR DESCRIPTION
This new feature was added to provider section to scan all the content providers on the phone, find the providers URIs and make a query for each URI. Returns the following result to the client:

When the query is succeeded: 
    VULNERABLE com.package.name -> uri: content://com.package.authority/
When the query fail:
    SAFE com.package.name -> uri: content://com.package.authority/

This result is presented because when the query to the content provider is succesful, means that the provider is open to any application to access, that is a possible VULNERABLE provider. Otherwise, when the query fails, the provider is SAFE and not open to other application.

The performance of this feature, however, is very depleted because the Common.strings function is very slow. This problem is solved applying the patch proposed by rchiossi.
