### PR TITLE
Added providerscan module to scan all providers and added color feature in linux terminal

### DIFF
--- a/client/merc/lib/common.py
+++ b/client/merc/lib/common.py
@@ -22,6 +22,48 @@ debug_mode = False
 # Define a dictionary of all intents and their corresponding string values
 intentDictionary = {"ACTION_AIRPLANE_MODE_CHANGED":"android.intent.action.AIRPLANE_MODE", "ACTION_ALL_APPS":"android.intent.action.ALL_APPS", "ACTION_ANSWER":"android.intent.action.ANSWER", "ACTION_ATTACH_DATA":"android.intent.action.ATTACH_DATA", "ACTION_BATTERY_CHANGED":"android.intent.action.BATTERY_CHANGED", "ACTION_BATTERY_LOW":"android.intent.action.BATTERY_LOW", "ACTION_BATTERY_OKAY":"android.intent.action.BATTERY_OKAY", "ACTION_BOOT_COMPLETED":"android.intent.action.BOOT_COMPLETED", "ACTION_BUG_REPORT":"android.intent.action.BUG_REPORT", "ACTION_CALL":"android.intent.action.CALL", "ACTION_CALL_BUTTON":"android.intent.action.CALL_BUTTON", "ACTION_CAMERA_BUTTON":"android.intent.action.CAMERA_BUTTON", "ACTION_CHOOSER":"android.intent.action.CHOOSER", "ACTION_CLOSE_SYSTEM_DIALOGS":"android.intent.action.CLOSE_SYSTEM_DIALOGS", "ACTION_CONFIGURATION_CHANGED":"android.intent.action.CONFIGURATION_CHANGED", "ACTION_CREATE_SHORTCUT":"android.intent.action.CREATE_SHORTCUT", "ACTION_DATE_CHANGED":"android.intent.action.DATE_CHANGED", "ACTION_DEFAULT":"android.intent.action.VIEW", "ACTION_DELETE":"android.intent.action.DELETE", "ACTION_DEVICE_STORAGE_LOW":"android.intent.action.DEVICE_STORAGE_LOW", "ACTION_DEVICE_STORAGE_OK":"android.intent.action.DEVICE_STORAGE_OK", "ACTION_DIAL":"android.intent.action.DIAL", "ACTION_DOCK_EVENT":"android.intent.action.DOCK_EVENT", "ACTION_EDIT":"android.intent.action.EDIT", "ACTION_EXTERNAL_APPLICATIONS_AVAILABLE":"android.intent.action.EXTERNAL_APPLICATIONS_AVAILABLE", "ACTION_EXTERNAL_APPLICATIONS_UNAVAILABLE":"android.intent.action.EXTERNAL_APPLICATIONS_UNAVAILABLE", "ACTION_FACTORY_TEST":"android.intent.action.FACTORY_TEST", "ACTION_GET_CONTENT":"android.intent.action.GET_CONTENT", "ACTION_GTALK_SERVICE_CONNECTED":"android.intent.action.GTALK_CONNECTED", "ACTION_GTALK_SERVICE_DISCONNECTED":"android.intent.action.GTALK_DISCONNECTED", "ACTION_HEADSET_PLUG":"android.intent.action.HEADSET_PLUG", "ACTION_INPUT_METHOD_CHANGED":"android.intent.action.INPUT_METHOD_CHANGED", "ACTION_INSERT":"android.intent.action.INSERT", "ACTION_INSERT_OR_EDIT":"android.intent.action.INSERT_OR_EDIT", "ACTION_LOCALE_CHANGED":"android.intent.action.LOCALE_CHANGED", "ACTION_MAIN":"android.intent.action.MAIN", "ACTION_MANAGE_PACKAGE_STORAGE":"android.intent.action.MANAGE_PACKAGE_STORAGE", "ACTION_MEDIA_BAD_REMOVAL":"android.intent.action.MEDIA_BAD_REMOVAL", "ACTION_MEDIA_BUTTON":"android.intent.action.MEDIA_BUTTON", "ACTION_MEDIA_CHECKING":"android.intent.action.MEDIA_CHECKING", "ACTION_MEDIA_EJECT":"android.intent.action.MEDIA_EJECT", "ACTION_MEDIA_MOUNTED":"android.intent.action.MEDIA_MOUNTED", "ACTION_MEDIA_NOFS":"android.intent.action.MEDIA_NOFS", "ACTION_MEDIA_REMOVED":"android.intent.action.MEDIA_REMOVED", "ACTION_MEDIA_SCANNER_FINISHED":"android.intent.action.MEDIA_SCANNER_FINISHED", "ACTION_MEDIA_SCANNER_SCAN_FILE":"android.intent.action.MEDIA_SCANNER_SCAN_FILE", "ACTION_MEDIA_SCANNER_STARTED":"android.intent.action.MEDIA_SCANNER_STARTED", "ACTION_MEDIA_SHARED":"android.intent.action.MEDIA_SHARED", "ACTION_MEDIA_UNMOUNTABLE":"android.intent.action.MEDIA_UNMOUNTABLE", "ACTION_MEDIA_UNMOUNTED":"android.intent.action.MEDIA_UNMOUNTED", "ACTION_NEW_OUTGOING_CALL":"android.intent.action.NEW_OUTGOING_CALL", "ACTION_PACKAGE_ADDED":"android.intent.action.PACKAGE_ADDED", "ACTION_PACKAGE_CHANGED":"android.intent.action.PACKAGE_CHANGED", "ACTION_PACKAGE_DATA_CLEARED":"android.intent.action.PACKAGE_DATA_CLEARED", "ACTION_PACKAGE_INSTALL":"android.intent.action.PACKAGE_INSTALL", "ACTION_PACKAGE_REMOVED":"android.intent.action.PACKAGE_REMOVED", "ACTION_PACKAGE_REPLACED":"android.intent.action.PACKAGE_REPLACED", "ACTION_PACKAGE_RESTARTED":"android.intent.action.PACKAGE_RESTARTED", "ACTION_PICK_ACTIVITY":"android.intent.action.PICK_ACTIVITY", "ACTION_PICK":"android.intent.action.PICK", "ACTION_POWER_CONNECTED":"android.intent.action.ACTION_POWER_CONNECTED", "ACTION_POWER_DISCONNECTED":"android.intent.action.ACTION_POWER_DISCONNECTED", "ACTION_POWER_USAGE_SUMMARY":"android.intent.action.POWER_USAGE_SUMMARY", "ACTION_PROVIDER_CHANGED":"android.intent.action.PROVIDER_CHANGED", "ACTION_REBOOT":"android.intent.action.REBOOT", "ACTION_RUN":"android.intent.action.RUN", "ACTION_SCREEN_OFF":"android.intent.action.SCREEN_OFF", "ACTION_SCREEN_ON":"android.intent.action.SCREEN_ON", "ACTION_SEARCH":"android.intent.action.SEARCH", "ACTION_SEARCH_LONG_PRESS":"android.intent.action.SEARCH_LONG_PRESS", "ACTION_SEND":"android.intent.action.SEND", "ACTION_SEND_MULTIPLE":"android.intent.action.SEND_MULTIPLE", "ACTION_SENDTO":"android.intent.action.SENDTO", "ACTION_SET_WALLPAPER":"android.intent.action.SET_WALLPAPER", "ACTION_SHUTDOWN":"android.intent.action.ACTION_SHUTDOWN", "ACTION_SYNC":"android.intent.action.SYNC", "ACTION_SYSTEM_TUTORIAL":"android.intent.action.SYSTEM_TUTORIAL", "ACTION_TIME_CHANGED":"android.intent.action.TIME_SET", "ACTION_TIME_TICK":"android.intent.action.TIME_TICK", "ACTION_TIMEZONE_CHANGED":"android.intent.action.TIMEZONE_CHANGED", "ACTION_UID_REMOVED":"android.intent.action.UID_REMOVED", "ACTION_UMS_CONNECTED":"android.intent.action.UMS_CONNECTED", "ACTION_UMS_DISCONNECTED":"android.intent.action.UMS_DISCONNECTED", "ACTION_USER_PRESENT":"android.intent.action.USER_PRESENT", "ACTION_VIEW":"android.intent.action.VIEW", "ACTION_VOICE_COMMAND":"android.intent.action.VOICE_COMMAND", "ACTION_WALLPAPER_CHANGED":"android.intent.action.WALLPAPER_CHANGED", "ACTION_WEB_SEARCH":"android.intent.action.WEB_SEARCH", "CATEGORY_ALTERNATIVE":"android.intent.category.ALTERNATIVE", "CATEGORY_BROWSABLE":"android.intent.category.BROWSABLE", "CATEGORY_CAR_DOCK":"android.intent.category.CAR_DOCK", "CATEGORY_CAR_MODE":"android.intent.category.CAR_MODE", "CATEGORY_DEFAULT":"android.intent.category.DEFAULT", "CATEGORY_DESK_DOCK":"android.intent.category.DESK_DOCK", "CATEGORY_DEVELOPMENT_PREFERENCE":"android.intent.category.DEVELOPMENT_PREFERENCE", "CATEGORY_EMBED":"android.intent.category.EMBED", "CATEGORY_FRAMEWORK_INSTRUMENTATION_TEST":"android.intent.category.FRAMEWORK_INSTRUMENTATION_TEST", "CATEGORY_HOME":"android.intent.category.HOME", "CATEGORY_INFO":"android.intent.category.INFO", "CATEGORY_LAUNCHER":"android.intent.category.LAUNCHER", "CATEGORY_MONKEY":"android.intent.category.MONKEY", "CATEGORY_OPENABLE":"android.intent.category.OPENABLE", "CATEGORY_PREFERENCE":"android.intent.category.PREFERENCE", "CATEGORY_SAMPLE_CODE":"android.intent.category.SAMPLE_CODE", "CATEGORY_SELECTED_ALTERNATIVE":"android.intent.category.SELECTED_ALTERNATIVE", "CATEGORY_TAB":"android.intent.category.TAB", "CATEGORY_TEST":"android.intent.category.TEST", "CATEGORY_UNIT_TEST":"android.intent.category.UNIT_TEST", "EXTRA_ALARM_COUNT":"android.intent.extra.ALARM_COUNT", "EXTRA_BCC":"android.intent.extra.BCC", "EXTRA_CC":"android.intent.extra.CC", "EXTRA_CHANGED_COMPONENT_NAME":"android.intent.extra.changed_component_name", "EXTRA_CHANGED_COMPONENT_NAME_LIST":"android.intent.extra.changed_component_name_list", "EXTRA_CHANGED_PACKAGE_LIST":"android.intent.extra.changed_package_list", "EXTRA_CHANGED_UID_LIST":"android.intent.extra.changed_uid_list", "EXTRA_DATA_REMOVED":"android.intent.extra.DATA_REMOVED", "EXTRA_DOCK_STATE":"android.intent.extra.DOCK_STATE", "EXTRA_DONT_KILL_APP":"android.intent.extra.DONT_KILL_APP", "EXTRA_EMAIL":"android.intent.extra.EMAIL", "EXTRA_INITIAL_INTENTS":"android.intent.extra.INITIAL_INTENTS", "EXTRA_INTENT":"android.intent.extra.INTENT", "EXTRA_KEY_EVENT":"android.intent.extra.KEY_EVENT", "EXTRA_PHONE_NUMBER":"android.intent.extra.PHONE_NUMBER", "EXTRA_REMOTE_INTENT_TOKEN":"android.intent.extra.remote_intent_token", "EXTRA_REPLACING":"android.intent.extra.REPLACING", "EXTRA_SHORTCUT_ICON":"android.intent.extra.shortcut.ICON", "EXTRA_SHORTCUT_ICON_RESOURCE":"android.intent.extra.shortcut.ICON_RESOURCE", "EXTRA_SHORTCUT_INTENT":"android.intent.extra.shortcut.INTENT", "EXTRA_SHORTCUT_NAME":"android.intent.extra.shortcut.NAME", "EXTRA_STREAM":"android.intent.extra.STREAM", "EXTRA_SUBJECT":"android.intent.extra.SUBJECT", "EXTRA_TEMPLATE":"android.intent.extra.TEMPLATE", "EXTRA_TEXT":"android.intent.extra.TEXT", "EXTRA_TITLE":"android.intent.extra.TITLE", "EXTRA_UID":"android.intent.extra.UID"}
 
+class Color:
+    """Write coloured text on linux terminal,
+       Write normal text on Windows Command Prompt.
+       Added by Luander <luander.r@samsung.com>
+    """
+    OKGREEN = "\033[92m"
+    ENDC = "\033[0m"
+    FAIL = "\033[91m"
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    WARNING = "\033[93m"
+
+    def fail(self, text):
+        if (os.name == "posix"):
+            return self.FAIL + text + self.ENDC
+        else:
+            return text
+
+    def okgreen(self, text):
+        if (os.name == "posix"):
+            return self.OKGREEN + text + self.ENDC
+        else:
+            return text
+
+    def warning(self, text):
+        if (os.name == "posix"):
+            return self.WARNING + text + self.ENDC
+        else:
+            return text
+
+    def okblue(self, text):
+        if (os.name == "posix"):
+            return self.OKBLUE + text + self.ENDC
+        else:
+            return text
+
+    def header(self, text):
+        if (os.name == "posix"):
+            return self.HEADER + text + self.ENDC
+        else:
+            return text
+
 class Response:
     """Response class"""
 
@@ -66,6 +108,8 @@ class Session:
         self.port = port
         self.direction = direction
         self.socketConn = None
+        # Field to manage colors on linux terminal, see #Colors for more information
+        self.color = Color()
 
     def __del__(self):
         try:

--- a/client/merc/modules/information/findproviders.py
+++ b/client/merc/modules/information/findproviders.py
@@ -1,0 +1,55 @@
+from merc.lib.modules import Module
+import re, string
+
+class ProviderScan(Module):
+    """Usage: run information.providerscan --arg <filter>
+    Search for all packages and tries to query respective providers, a filter can be added to restrict queries to a specific package 
+    Credit: Luander <luander.r@samsung.com> - Samsung SIDI 
+    """
+
+    def __init__(self, *args, **kwargs):
+        Module.__init__(self, *args, **kwargs)
+        self.path = ["information"]
+        
+    def execute(self, session, _arg):
+
+        reqres = session.executeCommand("packages", "info", {"filter":_arg}).getPaddedErrorOrData()
+        packlist = re.findall('(?<=Package name: ).+', reqres)
+        uris = []
+        for package in packlist:
+            path = session.executeCommand("packages", "path", {'packageName':package}).data
+            # Iterate through paths returned
+            for line in path.split():
+
+                if (".apk" in line):
+                    if session.executeCommand("core", "unzip", {'path':line, 'destination':'/data/data/com.mwr.mercury/'}).isError():
+                        pass
+                    else:
+
+                        strings = session.executeCommand("core", "strings", {'path':'/data/data/com.mwr.mercury/classes.dex'}).data
+
+                        for string in strings.split():
+                            if (("CONTENT://" in string.upper()) and ("CONTENT://" != string.upper())):
+                                uris.append(string[string.upper().find("CONTENT"):]) 
+
+                        # Delete classes.dex
+                        session.executeCommand("core", "delete", {'path':'/data/data/com.mwr.mercury/classes.dex'})
+
+                if (".odex" in line):
+                    strings = session.executeCommand("core", "strings", {'path':line}).data
+
+                    for string in strings.split():
+                        if (("CONTENT://" in string.upper()) and ("CONTENT://" != string.upper())):
+                            uris.append(string[string.upper().find("CONTENT"):])
+                    
+            for uri in uris:
+                
+                response = session.executeCommand("provider", "query", {"Uri":uri})
+                
+                if response.isError():
+                    print "Unable to query -> " + package + " - " + uri 
+                    continue
+                else:
+                    print session.color.fail("Able to query") + " -> " + package + " - " + uri
+            uris = []
+ 


### PR DESCRIPTION
In this pull request I've added a new client module to scan all content providers on the phone and try to query them. 

If the query succeeded the module prints:
Able to query -> <package name> - <uri>
else the module prints:
Unable to query -> <package name> - <uri>

Also, I added a new class in common.py called Color to print coloured words on linux terminal.
To print coloured text, simply call 'session.color.fail("<coloured text>")'. This prints a red fail text on terminal.

Luander
