### PR TITLE
Added support for inline commands

### DIFF
--- a/client/mercury.py
+++ b/client/mercury.py
@@ -14,19 +14,23 @@ import sys
 class Mercury(BaseCmd):
 
     def __init__(self):
-        #if len(sys.argv) > 1 and len(sys.argv) <= 2:
-        #sys.stdin = open(sys.argv.pop())
-
-        parser = argparse.ArgumentParser(prog = 'resource', add_help = False)
+        """
+When using a resource file as input, remember to always end the file with "exit" command,
+otherwise Mercury will enter in an infinite loop.
+        """
+        parser = BaseArgumentParser(prog = 'mercury.py', add_help = False)
         parser.add_argument('--resource', '-r', metavar = '<resource>')
 
         sys.argv.remove(sys.argv[0])
 
         splitargs = parser.parse_args(sys.argv)
 
-        resourceFile = splitargs.resource
-        if resourceFile is not None:
-            sys.stdin = open(resourceFile)
+        if splitargs is not None:
+            resourceFile = splitargs.resource
+            if resourceFile is not None:
+                sys.stdin = open(resourceFile)
+        else:
+            raise AttributeError()
 
         BaseCmd.__init__(self, None)
         self.prompt = "mercury> "
@@ -181,3 +185,6 @@ if __name__ == '__main__':
         console.cmdloop()
     except IOError:
         print 'Error on opening resource file.'
+    except AttributeError:
+        pass
+


### PR DESCRIPTION
Hi,
I've added a basic inline command support.
Now you can write a sequence of commands in a file and run mercury with this file as input.
The commands in the file must start with "connect <IP>" and end with "exit", otherwise Mercury will not run properly.
In the future will be necessary to add a parser to validate the commands file.
