### PR TITLE
Specify Java 1.6 as target VM during compilation

### DIFF
--- a/src/pydiesel/reflection/utils/class_builder.py
+++ b/src/pydiesel/reflection/utils/class_builder.py
@@ -33,7 +33,7 @@ class ClassBuilder(object):
             # switch our working directory to the source directory
             os.chdir(os.path.dirname(self.path))
             # compile the java sources (%.java => %.class)
-            if not self.__execute(self.javac , "-cp", self.sdk_path, os.path.basename(self.path)):
+            if not self.__execute(self.javac, "-source", "1.6", "-target", "1.6", "-cp", self.sdk_path, os.path.basename(self.path)):
                 raise RuntimeError("Error whilst compiling the Java sources.")
             
             # collect any sub-classes that we generated


### PR DESCRIPTION
This removes the need to have a separate Java 6 SDK install.

Previously, if ``which javac`` pointed to a Java 7+ javac, and you hadn't manually updated your `.drozer_config` file to point to a javac 1.6 install, dx would throw the following error when packaging an APK.

```
dz> run exploit.jdwp.check
/usr/bin/javac -cp /Users/joe/Tools/drozer/drozer/src/drozer/lib/android.jar JdwpBroker.java
/Users/joe/Tools/drozer/drozer/src/drozer/lib/dx --dex --output 237679523de7d4aa437a3b275110db94.apk     JdwpBroker.class

trouble processing:
bad class file magic (cafebabe) or version (0033.0000)
...while parsing JdwpBroker.class
...while processing JdwpBroker.class
1 warning
no classfiles specified 
Error whilst building APK bundle.
```

By passing `-source 1.6 -target 1.6` we can tell `javac` to build a Java 6 compatible class file.

An alternative fix may be to update the bundled `dx.jar`, as `dx` now support Java 7 - but I think the same error would be thrown if a user had the Java 8 SDK installed... 
