### PR TITLE
Revert back to the old way of getting data dir on SDK < 24

### DIFF
--- a/src/drozer/console/session.py
+++ b/src/drozer/console/session.py
@@ -53,8 +53,10 @@ class Session(cmd.Cmd):
             self.stderr = DecolouredStream(self.stderr)
 
         m = Module(self)
-        if m.has_context():
+        if m.has_context() and self.reflector.resolve("android.os.Build$VERSION").SDK_INT >= 24:
             dataDir = str(m.getContext().getDataDir().getCanonicalPath().native())
+        elif m.has_context():
+            dataDir = str(m.getContext().getApplicationInfo().dataDir)
         else:
             dataDir = str(m.new("java.io.File", ".").getCanonicalPath().native())
         self.variables = {  'PATH': dataDir +'/bin:/sbin:/vendor/bin:/system/sbin:/system/bin:/system/xbin',


### PR DESCRIPTION
`Context.getDataDir()` is not present in SDK < 24. This provides a fallback to how drozer 2 did things.

This fixes issue https://github.com/WithSecureLabs/drozer/issues/414 - a quick test suggests that drozer otherwise works on Android 6.0.0, but further testing/debugging may be needed.