### PR TITLE
Handle all exception types in `ModuleLoader`

### DIFF
--- a/src/drozer/modules/loader.py
+++ b/src/drozer/modules/loader.py
@@ -56,6 +56,9 @@ class ModuleLoader(object):
                 except IndentationError:
                     sys.stderr.write("Skipping source file at %s. Indentation Error.\n" % modules[i])
                     pass
+                except Exception as e:
+                    sys.stderr.write("Skipping source file at {0}. {1}.\n".format(modules[i], type(e).__name__))
+                    pass
 
     def __load(self, base):
         """


### PR DESCRIPTION
drozer's module loader will gracefully skip over a broken module if it contains indentation errors, or if an `ImportError` is thrown. However, this does not account for e.g., `SyntaxErrors` (you know how all old modules are Python 2? Yea...)

So, let's just catch all `Exceptions` here and throw a moderately unhelpful error at the user.

With this in place, we can re-enable the module repo. Even if all the modules in it are broken, they at least won't break drozer completely.