### PR TITLE
Remove conditional logic on `scanner.provider.traveral`'s exception handler

### DIFF
--- a/src/drozer/modules/scanner/provider/traversal.py
+++ b/src/drozer/modules/scanner/provider/traversal.py
@@ -52,14 +52,7 @@ class Traversal(Module, common.FileSystem, common.PackageManager, common.Provide
         try:
             data = self.contentResolver().read(uri + "/../../../../../../../../../../../../../../../../etc/hosts")
         except ReflectionException as e:
-            if "java.io.FileNotFoundException" in str(e) or \
-                "java.lang.IllegalArgumentException" in str(e) or \
-                "java.lang.SecurityException" in str(e) or \
-                "No content provider" in str(e) or \
-                "RuntimeException" in str(e):
-                data = ""
-            else:
-                raise
+            data = ""
     
         if data != None and len(data) > 0:
             vulnerable.add(uri)


### PR DESCRIPTION
the logic of the `__test_uri()` function of the `scanner.provider.traversal` module. In drozer 2, this was implemented as follows:

```python
    def __test_uri(self, uri, vulnerable):
        try:
            data = self.contentResolver().read(uri + "/../../../../../../../../../../../../../../../../etc/hosts")
        except ReflectionException as e:
            if e.message.find("java.io.FileNotFoundException") >= 0 or \
                e.message.find("java.lang.IllegalArgumentException") >= 0 or \
                e.message.find("java.lang.SecurityException") >= 0 or \
                e.message.find("No content provider") >= 0 or \
                e.message.find("RuntimeException"):
                data = ""
            else:
                raise
    
        if data != None and len(data) > 0:
            vulnerable.add(uri)
```

A cursory read of the `try`/`except` block makes it seem like an exception should be suppressed if it contains one of five strings, and raised otherwise. So, it got ported to Python 3/drozer 3 as:

```python
    def __test_uri(self, uri, vulnerable):
        try:
            data = self.contentResolver().read(uri + "/../../../../../../../../../../../../../../../../etc/hosts")
        except ReflectionException as e:
            if "java.io.FileNotFoundException" in str(e) or \
                "java.lang.IllegalArgumentException" in str(e) or \
                "java.lang.SecurityException" in str(e) or \
                "No content provider" in str(e) or \
                "RuntimeException" in str(e):
                data = ""
            else:
                raise
    
        if data != None and len(data) > 0:
            vulnerable.add(uri)
```

This is all sensible at a glance, but the **drozer 2** logic was actually flawed - if the string `RuntimeException` was NOT found, `string.find()` would return `-1`, causing the entire `if` statement to evaluate as `True`. In practice, this means that it set `data` to `""` if `e.message` contained one of the first four strings OR didn't start with `RuntimeException`. The only way for it to really go `False` would be to start with "RuntimeException" and not contain any of the other four strings. This probably always evaluated as `True`.

Now, **drozer 3**'s logic attempts to implement the same intention, but as a result it ends up with a statement that throws the exception much more often. My suspicion is that drozer 2 worked _by accident_. Since drozer 2 _de facto_ performed no checks on the exception message, let's get rid of the broken checks and just let it do its thang.