### PR TITLE
Correct pip requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
-python
-git
-android-tools
-python-protobuf
-python-pyopenssl
-python-twisted
-python-setuptools
-python-distro
+protobuf>=4.25.2
+pyopenssl>=22.0.0
+twisted>=18.9.0
+service-identity
+distro
+pyyaml

--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,11 @@ setuptools.setup(
                     "pysolar": "src/pysolar" },
   package_data = get_package_data(),
   scripts = get_executable_scripts(),
-  install_requires = ["protobuf>=2.6.1","pyopenssl>=16.2", "pyyaml>=3.11"],
+  install_requires = [  "protobuf>=4.25.2",
+                        "pyopenssl>=22.0.0",
+                        "twisted>=18.9.0",
+                        "service-identity",
+                        "distro",
+                        "pyyaml" ],
   data_files = get_install_data(),
   classifiers = [])


### PR DESCRIPTION
Update the requirements in the Python wheel (apparently we didn't do that), and introduce a coherent `requirements.txt` file