### PR TITLE
Gather useful info from generic exceptions in debug mode

### DIFF
--- a/src/WithSecure/common/cmd_ext.py
+++ b/src/WithSecure/common/cmd_ext.py
@@ -98,7 +98,8 @@ class Cmd(cmd.Cmd):
                         raise
             self.postloop()
         except Exception as e:
-            print(f"Loop exception {e}")
+            print("Loop exception")
+            self.handleException(e)
             pass
 
         finally:
@@ -233,11 +234,12 @@ class Cmd(cmd.Cmd):
 
         pass
 
-    def handleException(self, e):
+    def handleException(self, e, shutup=False):
         """
         Default exception handler, writes the message to stderr.
         """
-
+        if(shutup):
+            return
         self.stderr.write("Exception occured: %s\n" % str(e))
 
     def postcmd(self, stop, line):

--- a/src/drozer/console/console.py
+++ b/src/drozer/console/console.py
@@ -73,7 +73,14 @@ class Console(cli.Base):
             except KeyboardInterrupt:
                 print("Caught SIGINT, terminating your session.")
             except Exception as e:
-                print(f"Caught Exception {e}")
+                # session might not exist here, so let's accept some code duplication
+                if session is not None:
+                    session.handleException(e)
+                elif(arguments.debug):
+                    sys.stderr.write("exception in: {}: {}\n".format(e.__class__.__name__, str(e)))
+                    sys.stderr.write("%s\n"%traceback.format_exc())
+                else:
+                    sys.stderr.write("Exception occured: %s\n" % str(e))
             finally:
                 session.do_exit("")
                 

--- a/src/drozer/console/console.py
+++ b/src/drozer/console/console.py
@@ -1,6 +1,7 @@
 import getpass
 import sys
 import warnings
+import traceback
 
 from pysolar.api.protobuf_pb2 import Message
 from pysolar.api.transport.exceptions import ConnectionError

--- a/src/drozer/console/session.py
+++ b/src/drozer/console/session.py
@@ -403,9 +403,6 @@ class Session(cmd.Cmd):
             except KeyboardInterrupt:
                 self.stderr.write("\nCaught SIGINT. Interrupt again to terminate you session.\n")
             except Exception as e:
-                # yaynoteyay
-                # commenting out because `self.handleException(e)` does the same thing anyway
-                #print(f"Exception occured: {e}")
                 self.handleException(e)
             
             while self.__module_pushed_completers > 0:
@@ -598,7 +595,9 @@ class Session(cmd.Cmd):
                 elif meta.version < latest:
                     print("It seems that you are running an old version of drozer. drozer v%s was\nreleased on %s. We suggest that you update your copy to make sure that\nyou have the latest features and fixes.\n\nTo download the latest drozer visit: https://labs.withsecure.com/tools/drozer/\n" % (latest, latest.date))
         except Exception as e:
-            pass #TODO figure out what this exception is and handle appropriately (exp. IOError)
+            #silence this exception unless in debug mode
+            self.handleException(e, shutup=True)
+            pass
 
     def sendAndReceive(self, message):
         """
@@ -841,9 +840,9 @@ class DebugSession(Session):
         
         self.stdout.write("Done.\n\n")
 
-    def handleException(self, e):
+    def handleException(self, e, shutup=False):
         """
-        Invoked whenever an exception is triggered by a module, to handle the
+        Invoked whenever an exception is triggered, to handle the
         throwable and display some information to the user.
         """
         self.stderr.write("exception in module: {}: {}\n".format(e.__class__.__name__, str(e)))

--- a/src/drozer/modules/loader.py
+++ b/src/drozer/modules/loader.py
@@ -58,6 +58,7 @@ class ModuleLoader(object):
                     pass
                 except Exception as e:
                     sys.stderr.write("Skipping source file at {0}. {1}.\n".format(modules[i], type(e).__name__))
+                    sys.stderr.write("%s\n"%traceback.format_exc())
                     pass
 
     def __load(self, base):

--- a/src/drozer/modules/loader.py
+++ b/src/drozer/modules/loader.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import importlib
+import traceback
 
 from drozer.modules.import_conflict_resolver import ImportConflictResolver
 from drozer.repoman import Repository

--- a/src/drozer/modules/scanner/activity/browsable.py
+++ b/src/drozer/modules/scanner/activity/browsable.py
@@ -1,5 +1,6 @@
 from drozer.modules import common, Module
 import xml.etree.ElementTree as ET
+import sys
 
 class Browsable(Module, common.PackageManager, common.Assets):
     name = "Get all BROWSABLE activities that can be invoked from the web browser"
@@ -48,6 +49,7 @@ Package: com.android.mms
     def add_arguments(self, parser):
         parser.add_argument("-a", "--package", help="specify a package to search")
         parser.add_argument("-f", "--filter", action="store", dest="filter", default=None, help="filter term")
+        parser.add_argument("--debug", action="store_true", default=False, help="enable debug mode")
 
     def execute(self, arguments):
 
@@ -80,6 +82,9 @@ Package: com.android.mms
                             self.stdout.write("    %s\n" % str(i))
                         self.stdout.write("\n")
             except Exception as e:
+                if(arguments.debug):
+                    sys.stderr.write("exception in: {}: {}\n".format(e.__class__.__name__, str(e)))
+                    sys.stderr.write("%s\n"%traceback.format_exc())
                 pass # amazing error checking
             
     # Get browsable activities that use data attribute

--- a/src/drozer/modules/scanner/activity/browsable.py
+++ b/src/drozer/modules/scanner/activity/browsable.py
@@ -1,6 +1,7 @@
 from drozer.modules import common, Module
 import xml.etree.ElementTree as ET
 import sys
+import traceback
 
 class Browsable(Module, common.PackageManager, common.Assets):
     name = "Get all BROWSABLE activities that can be invoked from the web browser"


### PR DESCRIPTION
Most unhelpful exception messages should now expand to something sensible if the `--debug` arg is provided