### PR TITLE
`ModuleLoader` bugfixes

### DIFF
--- a/src/drozer/configuration.py
+++ b/src/drozer/configuration.py
@@ -88,7 +88,7 @@ class Configuration(object):
         cls.__ensure_config()
         
         if cls.__config.has_section(section):
-            return map(lambda k: cls.__config.get(section, k), cls.__config.options(section))
+            return list(map(lambda k: cls.__config.get(section, k), cls.__config.options(section)))
         else:
             return []
         

--- a/src/drozer/modules/loader.py
+++ b/src/drozer/modules/loader.py
@@ -108,10 +108,10 @@ class ModuleLoader(object):
     def __module_path(self):
         """
         Calculate the full set of module paths, by combining internal paths with
-        those specified in the DROZER_MODULE_PATH environment variable.
+        user-specified paths from the drozer config file.
         """
 
-        return self.__module_paths + ":" + Repository.drozer_modules_path()
+        return [self.__module_paths] + Repository.all()
         
     def __paths(self):
         """
@@ -124,7 +124,7 @@ class ModuleLoader(object):
 
         paths = []
 
-        for p in self.__module_path().split(":"):
+        for p in self.__module_path():
             path = os.path.abspath(p)
 
             if path not in sys.path:

--- a/src/drozer/repoman/repositories.py
+++ b/src/drozer/repoman/repositories.py
@@ -64,15 +64,6 @@ class Repository(object):
             Configuration.delete('repositories', path)
         else:
             raise UnknownRepository(path)
-        
-    @classmethod
-    def drozer_modules_path(cls):
-        """
-        Returns the DROZER_MODULE_PATH, that was previously stored in an environment
-        variable.
-        """
-        
-        return ":".join(cls.all())
     
     @classmethod
     def enable(cls, path):


### PR DESCRIPTION
When the `DROIDHG_MODULE_PATH` was retired, the list of repositories carried on being presented as a `:`-delimited string, for seemingly no good reason. That string was built, and then immediately split to get a list - the equivalent of `":".join(someList).split(":")`.

This also introduced bugs in Windows, since every absolute path will contain a `:`. Consequently, the loader only worked sometimes (by accident) on Windows, and it usually tried to load a few irrelevant directories as repos.

Let's not do any of that and just pass lists around.