### PR TITLE
Fix configparser Attribute Error for python 3.12

### DIFF
--- a/src/drozer/configuration.py
+++ b/src/drozer/configuration.py
@@ -148,7 +148,7 @@ class Configuration(object):
         """
         
         if cls.__config == None:
-            cls.__config = configparser.SafeConfigParser()
+            cls.__config = configparser.ConfigParser()
             cls.__config.optionxform = lambda optionstr: optionstr.replace(":", "|")
             
             if os.path.exists(cls.path()):


### PR DESCRIPTION
When running drozer console (v3.0.2) on Ubuntu 24 and python version `3.12.3`, I experienced the following attribute error.
`AttributeError: module 'configparser' has no attribute 'SafeConfigParser'. Did you mean: 'RawConfigParser'?`.

- Looking at the Python3 documentation, `SafeConfigParser` is no longer supported in python 3.12 and the only supported options are `ConfigParser` and `RawConfigParser`
-  `RawConfigParser` is the ConfigParser that does not do interpolation and default `ConfigParser` supports interpolation.
- The commit fixes the Attribute error by deleting `SafeConfigParser` with the default `ConfigParser` which is backward compatible