### PR TITLE
Provider bugfixes

### DIFF
--- a/src/drozer/modules/app/provider.py
+++ b/src/drozer/modules/app/provider.py
@@ -215,18 +215,18 @@ Finding content providers that do not require permissions to read/write:
 
         if len(exported_providers) > 0 or arguments.unexported and len(providers) > 0:
             self.stdout.write("Package: %s\n" % package.packageName)
-
-            if not arguments.unexported:
-                for provider in exported_providers:
-                    for authority in provider.authority.split(";"):
-                        self.__print_provider(provider, authority, "  ")
-            else:
+            if(arguments.unexported):
                 self.stdout.write("  Exported Providers:\n")
-                for provider in exported_providers:
-                    for authority in provider.authority.split(";"):
-                        self.__print_provider(provider, authority, "    ")
+            for provider in exported_providers:
+                if(provider.authority == None):
+                    provider.authority = "null"
+                for authority in provider.authority.split(";"):
+                    self.__print_provider(provider, authority, "    " if arguments.unexported else "  ") # 2-space indent if we're only printing exported providers, 4 if we're doing both exported and unexported
+            if(arguments.unexported):
                 self.stdout.write("  Hidden Providers:\n")
                 for provider in hidden_providers:
+                    if(provider.authority == None):
+                        provider.authority = "null"
                     for authority in provider.authority.split(";"):
                         self.__print_provider(provider, authority, "    ")
             self.stdout.write("\n")

--- a/src/drozer/modules/auxiliary/web_content_resolver.py
+++ b/src/drozer/modules/auxiliary/web_content_resolver.py
@@ -60,8 +60,11 @@ class Handler(BaseHTTPRequestHandler):
         params = urllib.parse.parse_qs(url.query)
 
         try:
-            if not path or path[0] == 'list':
-                # if / or /list, produce a list of all known content provider uris
+            if not path:
+                # default behaviour: usage information
+                self.wfile.write(bytes(self.header + self.usage() + self.footer, "utf-8"))
+            elif path[0] == 'list':
+                # if /list, produce a list of all known exported content provider uris
                 output = self.__provider_list(filters=params.get('filter', [None])[0], permissions=params.get('permissions', [None])[0])
 
                 self.wfile.write(bytes(self.header + output + self.footer, "utf-8"))
@@ -191,10 +194,10 @@ class Handler(BaseHTTPRequestHandler):
 <h2>Usage instructions:</h2>
 
 <ul>
-<li>To access a list of providers:
-  <a href="http://localhost:%d/list">http://localhost:%s/providers</a></li>
+<li>To access a list of exported providers (<b>n.b.</b>, may take a few minutes):
+  <a href="http://localhost:%d/list">http://localhost:%s/list</a></li>
 
 <li>To access a particular provider:
-  http://localhost:%d/query?uri=<uri>&projection=<projection>&selection=<selection>&selectionArgs=<selectionArgs>&sortOrder=</li>
+  http://localhost:%d/query?uri=<b>&lt;uri&gt;</b>&projection=<b>&lt;projection&gt;</b>&selection=<b>&lt;selection&gt;</b>&selectionArgs=<b>&lt;selectionArgs&gt;</b>&sortOrder=<b>&lt;sortOrder&gt;</b></li>
 </ul>
 """ % (self.server.server_port, self.server.server_port, self.server.server_port)

--- a/src/drozer/modules/auxiliary/web_content_resolver.py
+++ b/src/drozer/modules/auxiliary/web_content_resolver.py
@@ -93,7 +93,7 @@ class Handler(BaseHTTPRequestHandler):
             provider.pathPermissions != None and True in map(lambda path: self.__eligible_path_permission(permissions, path), provider.pathPermissions)
 
     def __format_exception(self, e):
-        return "<h1>" + str(e.__class__) + "</h1><p>" + e.message + "</p>"
+        return "<h1>" + str(e.__class__) + "</h1><p>" + str(e) + "</p>"
 
     def __provider_list(self, filters=None, permissions=None):
         """
@@ -120,12 +120,19 @@ class Handler(BaseHTTPRequestHandler):
             return link("/?permissions=%s" % url, display or url)
 
         for package in self.module.packageManager().getPackages(common.PackageManager.GET_PROVIDERS):
+            
             if package.providers != None and (filters == None or filters.lower() in package.packageName.lower()):
                 for provider in package.providers:
 
                     if self.__eligible_provider(permissions, provider):
                         # Give the general values first
-                        authorities = provider.authority.split(";")
+
+                        if(not provider.exported):
+                            continue
+                        if(provider.authority != None):
+                            authorities = provider.authority.split(";")
+                        else:
+                            authorities = "null"
                         output += "<tr><td>%s</td>" % linkfilter(provider.packageName)
                         output += "<td colspan='2'>%s</td>" % "<br/>".join([linkcontent(a) for a in authorities])
                         output += "<td>%s</td>" % linkperm(provider.readPermission)

--- a/src/drozer/modules/common/package_manager.py
+++ b/src/drozer/modules/common/package_manager.py
@@ -107,7 +107,7 @@ class PackageManager(object):
             Get all installed packages, as a Java List<>.
             """
 
-            return self.__package_manager.getInstalledPackages(self.__package_manager.GET_META_DATA)
+            return self.__package_manager.getInstalledPackages(flags)
 
         def packageManager(self):
             """


### PR DESCRIPTION
At some point, `installedPackages()` got modified from

https://github.com/WithSecureLabs/drozer/blob/8a7a2853fb01d3500794e982a5b4963e9428e995/src/drozer/modules/common/package_manager.py#L106-L111

to

https://github.com/WithSecureLabs/drozer/blob/a9018a2f15000bec1d598174a4076125652fe21e/src/drozer/modules/common/package_manager.py#L105-L110

This means that every time we call `getPackages()` with flags other than `GET_META_DATA`, those flags get ignored. This is _very bad_, because a fair few modules request these flags.

This PR reverts the `installedPackages()` regression and introduces a few py2-to-py3 fixes to make related modules work again (now that they actually get some data). Closes #449 and #450 