### PR TITLE
Agent version check

### DIFF
--- a/src/WithSecure/common/cmd_ext.py
+++ b/src/WithSecure/common/cmd_ext.py
@@ -275,6 +275,7 @@ class Cmd(cmd.Cmd):
         return line
 
     def checkVer(self):
+        # check for new console versions
         try:
             latest, date = meta.latest_version()
             if latest is not None:
@@ -284,6 +285,18 @@ class Cmd(cmd.Cmd):
                     print("It seems that you are running an old version of drozer. drozer v%s was\nreleased on %s. We suggest that you update your copy to make sure that\nyou have the latest features and fixes.\n\nTo download the latest drozer visit:\nhttps://github.com/WithSecureLabs/drozer/releases\n" % (latest, date))
         except Exception as e:
             #silence this exception unless in debug mode
+            self.handleException(e, shutup=True)
+            pass
+        # check for new agent versions
+        try:
+            packageManager = self.context().getPackageManager()
+            pm = self.reflector.resolve("android.content.pm.PackageManager")
+            agentVersion = meta.Version(packageManager.getPackageInfo('com.WithSecure.dz', pm.GET_META_DATA).versionName)
+            latestAgent, dateAgent = meta.latest_agent_version()
+            if latestAgent is not None:
+                if agentVersion < latestAgent:
+                    print("It seems that you are running an old version of drozer-agent. drozer-agent v%s was\nreleased on %s. We suggest that you update your copy to make sure that\nyou have the latest features and fixes.\n\nTo download the latest drozer-agent visit:\nhttps://github.com/WithSecureLabs/drozer-agent/releases\n" % (latestAgent, dateAgent))
+        except Exception as e:
             self.handleException(e, shutup=True)
             pass
 

--- a/src/WithSecure/common/cmd_ext.py
+++ b/src/WithSecure/common/cmd_ext.py
@@ -289,9 +289,9 @@ class Cmd(cmd.Cmd):
             pass
         # check for new agent versions
         try:
-            packageManager = self.context().getPackageManager()
-            pm = self.reflector.resolve("android.content.pm.PackageManager")
-            agentVersion = meta.Version(packageManager.getPackageInfo('com.WithSecure.dz', pm.GET_META_DATA).versionName)
+            context = self.context()
+            packageManager = context.getPackageManager()
+            agentVersion = meta.Version(packageManager.getPackageInfo(context.getPackageName(), packageManager.GET_META_DATA).versionName)
             latestAgent, dateAgent = meta.latest_agent_version()
             if latestAgent is not None:
                 if agentVersion < latestAgent:

--- a/src/drozer/meta.py
+++ b/src/drozer/meta.py
@@ -40,6 +40,18 @@ def latest_version():
         return None
     except URLError:
         return None
+        
+def latest_agent_version():
+    try:
+        response = urlopen(Request("https://api.github.com/repos/WithSecureLabs/drozer-agent/releases/latest", None, {"user-agent": "drozer: %s" % str(version)}), None, 1)
+        latestTag = json.load(response)
+        latestAgentVersion = Version(latestTag["tag_name"]), latestTag["created_at"][:10]
+        return latestAgentVersion
+    except HTTPError:
+        return None
+    except URLError:
+        return None
+
 
 def print_version():
     print("%s %s\n" % ("drozer", version))


### PR DESCRIPTION
In a similar vein as the console version checker, we should notify the user where we believe their agent is outdated.

Please **do not merge just yet** - the current drozer-agent is incorrectly marked as version 2.5.2 even though it is tagged as 3.0.0 on GitHub; so, right now this change would alert every single user that their agent is outdated. We'll push this together with a new agent version :)