### PR TITLE
Follow 3xx redirects in repoman, improve error handling in case a bad repo makes it to the list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ twisted>=18.9.0
 service-identity
 distro
 pyyaml
+requests

--- a/src/drozer/repoman/installer.py
+++ b/src/drozer/repoman/installer.py
@@ -142,12 +142,18 @@ class ModuleInstaller(object):
         index = set([])
         
         for url in Remote.all():
-            source = Remote.get(url).download("INDEX.xml")
+            try:
+                source = Remote.get(url).download("INDEX.xml")
+            except NetworkException:
+                print(f'Could not retrieve INDEX.xml at {url=}. Skipping...\n')
+                source = None
             
             if source != None:
-                modules = xml.fromstring(source)
-
-                index = index.union(map(lambda m: ModuleInfo(url, m.attrib['name'], m.find("./description").text), modules.findall("./module")))
+                try:
+                    modules = xml.fromstring(source)
+                    index = index.union(map(lambda m: ModuleInfo(url, m.attrib['name'], m.find("./description").text), modules.findall("./module")))
+                except Exception:
+                    print(f'Could not parse INDEX.xml at {url=}. Skipping...\n')
         
         return filter(lambda m: m != None and m != "", index)
 

--- a/src/drozer/repoman/installer.py
+++ b/src/drozer/repoman/installer.py
@@ -144,16 +144,18 @@ class ModuleInstaller(object):
         for url in Remote.all():
             try:
                 source = Remote.get(url).download("INDEX.xml")
-            except NetworkException:
-                print(f'Could not retrieve INDEX.xml at {url=}. Skipping...\n')
+            except NetworkException as e:
+                print("[!]", e)
+                print(f'Skipping {url}...\n')
                 source = None
             
             if source != None:
                 try:
                     modules = xml.fromstring(source)
                     index = index.union(map(lambda m: ModuleInfo(url, m.attrib['name'], m.find("./description").text), modules.findall("./module")))
-                except Exception:
-                    print(f'Could not parse INDEX.xml at {url=}. Skipping...\n')
+                except Exception as e:
+                    print(f'[!] Could not parse INDEX.xml at {url}. {e}')
+                    print(f'Skipping {url}...\n')
         
         return filter(lambda m: m != None and m != "", index)
 

--- a/src/drozer/repoman/remotes.py
+++ b/src/drozer/repoman/remotes.py
@@ -85,7 +85,7 @@ class Remote(object):
         try:
             return self.getPath(module)
         except Exception as e:
-            raise NetworkException()
+            raise NetworkException(str(e))
 
     def getPath(self, path):
         """
@@ -94,6 +94,7 @@ class Remote(object):
 
         uri = self.buildPath(path)
         response = requests.get(uri)
+        response.raise_for_status()
         return response.content
 
 
@@ -102,11 +103,11 @@ class NetworkException(Exception):
     Raised if a Remote is not available, because of some network error.
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, message="There was a problem accessing the remote."):
+        super().__init__(message)
 
     def __str__(self):
-        return "There was a problem accessing the remote."
+        return super().__str__()
 
 
 class UnknownRemote(Exception):

--- a/src/drozer/repoman/remotes.py
+++ b/src/drozer/repoman/remotes.py
@@ -1,7 +1,4 @@
-import http.client as httplib
-import io
-import urllib.request as urllib2
-from urllib.parse import urlparse
+import requests
 
 from drozer.configuration import Configuration
 
@@ -96,32 +93,8 @@ class Remote(object):
         """
 
         uri = self.buildPath(path)
-        # TODO: This parsing logic is ugly, but it Works™
-        parsed_uri = urlparse(uri)
-        host = parsed_uri.netloc
-        get_path = parsed_uri.path
-        scheme = parsed_uri.scheme
-        if(scheme == "https"):
-            conn = httplib.HTTPSConnection(host)
-        else:
-            conn = httplib.HTTPConnection(host)
-        conn.request("GET", get_path, headers={"Host": host})
-        response = conn.getresponse()
-        response.begin()
-        data = response.read()
-        response.close()
-
-        return data
-
-
-class FakeSocket(io.StringIO):
-    """
-    FakeSocket is used to interface between urllib2 and httplib, which aren't
-    totally compatible.
-    """
-
-    def makefile(self, *args, **kwargs):
-        return self
+        response = requests.get(uri)
+        return response.content
 
 
 class NetworkException(Exception):


### PR DESCRIPTION
Fixes #467 by replacing the dubious URL fetching logic with standard `requests`
Also displays HTTP errors and XML parsing errors to the user rather than crashing. If one repo is broken, others will continue to work.